### PR TITLE
Update MSP300.cpp _read fixed

### DIFF
--- a/MSP300.cpp
+++ b/MSP300.cpp
@@ -122,7 +122,7 @@ void MSP300::_read(uint8_t bytes)
   for (int i= 0; i < bytes; i++)
   {
     _raw <<= 8;
-    _raw = _wire->read();
+    _raw |= _wire->read();
   }
 }
 


### PR DESCRIPTION
_read() function was missing or-ed read bytes with _raw from Wire object.